### PR TITLE
fix: revert absolute path in dotev

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,7 @@ import random
 import time
 from pathlib import Path
 
-config = dotenv_values(str(Path.home()) + '/health-bot/.env')
+config = dotenv_values('.env')
 
 healthbot = mysql.connector.connect(
   host=config['DB_HOST'],


### PR DESCRIPTION
This PR reverts the dotenv location to a relative path, which will allow us to work locally again